### PR TITLE
[templates] Update resource detection config

### DIFF
--- a/charts/opentelemetry-demo-datadog/templates/_otelconfig.tpl
+++ b/charts/opentelemetry-demo-datadog/templates/_otelconfig.tpl
@@ -55,7 +55,7 @@ processors:
   resourcedetection:
     # ensures host.name and other important resource tags
     # get picked up
-    detectors: [system, env]
+    detectors: [gcp, ecs, ec2, azure, system]
     timeout: 5s
     override: false
   # adds various tags related to k8s

--- a/charts/opentelemetry-demo-datadog/templates/_otelconfig.tpl
+++ b/charts/opentelemetry-demo-datadog/templates/_otelconfig.tpl
@@ -55,7 +55,7 @@ processors:
   resourcedetection:
     # ensures host.name and other important resource tags
     # get picked up
-    detectors: [gcp, ecs, ec2, azure, system]
+    detectors: [env, gcp, ecs, ec2, azure, system]
     timeout: 5s
     override: false
   # adds various tags related to k8s


### PR DESCRIPTION
The configuration needs to include cloud-provider specific detectors, otherwise it won't add the proper hostname