### PR TITLE
Change histograms mode to 'counters'

### DIFF
--- a/charts/opentelemetry-demo-datadog/otelcol-config.yaml
+++ b/charts/opentelemetry-demo-datadog/otelcol-config.yaml
@@ -150,6 +150,10 @@ exporters:
   datadog:
     host_metadata:
       tags: [env:otel]
+    metrics:
+      histograms:
+        mode: counters
+        send_count_sum_metrics: true
     api:
       key: "$DD_API_KEY"
 


### PR DESCRIPTION
### What does this PR do?

Change histograms mode to `counters` instead of the default `distributions`. Set `metrics::histograms::send_count_sum_metrics` to true.

Behavior is documented at https://docs.datadoghq.com/metrics/open_telemetry/otlp_metric_types/?tab=histogram