### PR TITLE
Remove logging exporter

### DIFF
--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: example-opentelemetry-collector:4317
         tls:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -16,7 +16,6 @@ data:
   relay: |
     exporters:
       debug: {}
-      logging: {}
     extensions:
       health_check: {}
     processors:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -87,9 +87,6 @@ configMap:
 config:
   exporters:
     debug: {}
-    # Will be removed in a future release.
-    # Use the debug exporter instead.
-    logging: {}
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -18,7 +18,6 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -18,7 +18,6 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -18,7 +18,6 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -18,7 +18,6 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -18,7 +18,6 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
-      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:


### PR DESCRIPTION
Logging exporter is causing errors on update collector deployment